### PR TITLE
Fix: Custom signer was not working

### DIFF
--- a/src/app/containers/Signers.ts
+++ b/src/app/containers/Signers.ts
@@ -1,15 +1,15 @@
 import { createContainer } from "unstated-next";
 import { useState, useEffect } from "react";
-import { ethers, Signer } from "ethers";
+import { ethers, Signer, Wallet } from "ethers";
 import Connection from "./Connection";
 
 const useSigners = () => {
   const { provider } = Connection.useContainer();
   const [internalSigner, setInternalSigner] = useState<Signer | null>(null);
-  const [customSigner, setCustomSigner] = useState<Signer | null>(null);
+  const [customSigner, setCustomSigner] = useState<Wallet | null>(null);
 
   const attemptSetCustomSigner = (customSignerString: string) => {
-    let mySigner;
+    let mySigner: Wallet;
     try {
       if (customSignerString.trim() !== "") {
         if (customSignerString.substring(0, 2) === "0x") {
@@ -19,6 +19,7 @@ const useSigners = () => {
           // mnemonic
           mySigner = ethers.Wallet.fromMnemonic(customSignerString.trim());
         }
+        mySigner = mySigner.connect(provider);
         setCustomSigner(mySigner);
       }
     } catch (error) {

--- a/test/projects/truffle/package.json
+++ b/test/projects/truffle/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "chain": "ganache-cli -p 8545 -d"
   },
   "keywords": [],
   "author": "",

--- a/test/projects/truffle/truffle-config.js
+++ b/test/projects/truffle/truffle-config.js
@@ -1,7 +1,9 @@
 module.exports = {
   networks: {
     develop: {
+      host: "localhost",
       port: 8545,
+      network_id: "*"
     },
     // config for e2e test
     test: {


### PR DESCRIPTION
The provider was not getting attached to the custom signer, now it is.

I should probably include a test in the future. Adding a test to `e2e-call-functions.test.ts` is probably the easiest way. Left as an exercise to the reader or if the bug comes up again.