### PR TITLE
Convert uints to bignumbers

### DIFF
--- a/src/app/features/function-call/useCallFunction.ts
+++ b/src/app/features/function-call/useCallFunction.ts
@@ -31,7 +31,7 @@ const useCallFunction = (args, types, fn, opts) => {
     // handle array and int types
     const processedArgs = args.map((arg, idx) => {
       const type = types[idx];
-      if (type.substring(0, 4) === "uint") return parseInt(arg);
+      if (type.substring(0, 4) === "uint") return ethers.utils.bigNumberify(arg);
       if (type.slice(-2) === "[]") return JSON.parse(arg);
       return arg;
     });


### PR DESCRIPTION
> Closes https://github.com/adrianmcli/eth95/issues/11

Fixes the error where you can't use numbers beyond 15 digits 

```
Error: invalid input argument (arg=“_value”, reason=“invalid number value”, value=100000000000000000, version=4.0.47)
```