### PR TITLE
Make getJsonFilePaths recursive

### DIFF
--- a/src/artifact-paths.ts
+++ b/src/artifact-paths.ts
@@ -2,12 +2,15 @@ import path from "path";
 import fs from "fs";
 
 export const getJsonFilePaths = (artifactPath: string): string[] => {
-  const files = fs.readdirSync(artifactPath);
-  const jsonFiles = files.filter(
-    (filename) => filename.split(".").pop()?.toLowerCase() === "json",
-  );
-  const jsonPaths = jsonFiles.map((filename) =>
-    path.join(artifactPath, filename),
-  );
-  return jsonPaths;
+  let result: string[] = []
+  const files = fs.readdirSync(artifactPath)
+  files.forEach(file => {
+    const childPath = path.join(artifactPath, file)
+    if (fs.statSync(childPath).isDirectory()) {
+      result.push(...getJsonFilePaths(childPath))
+    } else if (path.extname(childPath) === ".json") {
+      result.push(childPath)
+    }
+  })
+  return result.sort()
 };


### PR DESCRIPTION
This PR converts the `getJsonFilePaths` to be recursive. Hardhat (and probably other tool kits) maintain the contract folder structure in the artifacts directory. Eth95 was missing those files because it was only searching in the immediate folder.