### PR TITLE
Fix "invalid BigNumber" for uint256[] arguments

### DIFF
--- a/src/app/features/function-call/useCallFunction.ts
+++ b/src/app/features/function-call/useCallFunction.ts
@@ -31,8 +31,8 @@ const useCallFunction = (args, types, fn, opts) => {
     // handle array and int types
     const processedArgs = args.map((arg, idx) => {
       const type = types[idx];
-      if (type.substring(0, 4) === "uint") return ethers.BigNumber.from(arg);
       if (type.slice(-2) === "[]") return JSON.parse(arg);
+      if (type.substring(0, 4) === "uint") return ethers.BigNumber.from(arg);
       return arg;
     });
 


### PR DESCRIPTION
Problem:
Entering a list for a function taking in `uint256[]` failed.
![image](https://user-images.githubusercontent.com/10051819/221206502-5b9b7f96-e89e-4eab-baed-4a5afe0a763a.png)
![image](https://user-images.githubusercontent.com/10051819/221206705-7689d54d-c386-4f0f-978e-f137ce8c1d41.png)

Quick fix:
Check if array type first before checking if uint type